### PR TITLE
Changed the following:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ build-frontend:
 
 .PHONY: Build Plone 5.2
 build-backend:  ## Build Plone 5.2
-	(cd api && virtualenv --clear --python=python3 .)
+	(cd api && virtualenv  --python=python3 .)
 	(cd api && bin/pip install --upgrade pip)
 	(cd api && bin/pip install -r requirements.txt)
 	(cd api && bin/buildout)

--- a/api/buildout.cfg
+++ b/api/buildout.cfg
@@ -1,9 +1,10 @@
 [buildout]
 extends =
     base.cfg
-    http://dist.plone.org/release/5.2.1/versions.cfg
+    http://dist.plone.org/release/5.2.2/versions.cfg
 find-links += http://dist.plone.org/thirdparty/
 versions=versions
+newest = false
 
 [versions]
 plone.restapi =


### PR DESCRIPTION
- buildout.cfg:
  - update versions of plone to 5.2.2 in order
  to avoid error about plone.schema = 1.2.0 pin
  - use newest = false in order to avoid
  buildout infinite subprocess recursion
- MakeFile:
  - remove --clear option as running the make
  on Ubuntu 20.04 removes the following files:
  - api/README.rst
  - api/base.cfg
  - api/buildout.cfg
  - api/requirements.txt
  - api/versions.cfg
  Without them the make fails to build